### PR TITLE
update 13.3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "rich" %}
 {% set version = "13.3.5" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - wheel
     - python
-    - poetry-core >=1.0.0 
+    - poetry-core >=1.0.0
   run:
     - markdown-it-py >=2.2.0,<3.0.0
     - pygments >=2.13.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rich" %}
-{% set version = "12.5.1" %}
+{% set version = "13.3.5" %}
 
 
 package:
@@ -8,12 +8,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca
+  sha256: 2d11b9b8dd03868f09b4fffadc84a6a8cda574e40dc90821bd845720ebb8e89c
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+  skip: True  # [py<37]
 
 requirements:
   host:
@@ -21,12 +21,12 @@ requirements:
     - setuptools
     - wheel
     - python
-    - poetry >=1.0.10
-    - poetry-core
+    - poetry-core >=1.0.10
   run:
+    - markdown-it-py >=2.2.0,<3.0.0
     - commonmark >=0.9.0,<0.10.0
     - dataclasses >=0.7,<0.9
-    - pygments >=2.6.0,<3.0.0
+    - pygments >=2.13.0,<3.0.0
     - python
     - typing_extensions >=4.0.0,<5.0.0
 
@@ -44,12 +44,11 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Rich is a Python library for rich text and beautiful formatting in the terminal.
-
   description: |
-    Rich is a Python library for rich text and beautiful formatting 
-    in the terminal.The Rich API makes it easy to add color and style to 
-    terminal output. Rich can also render pretty tables, progress bars, 
-    markdown, syntax highlighted source code, tracebacks, and more — out 
+    Rich is a Python library for rich text and beautiful formatting
+    in the terminal.The Rich API makes it easy to add color and style to
+    terminal output. Rich can also render pretty tables, progress bars,
+    markdown, syntax highlighted source code, tracebacks, and more — out
     of the box.
   doc_url: https://rich.readthedocs.io/en/latest/
   dev_url: https://github.com/willmcgugan/rich

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - wheel
     - python
-    - poetry-core >=1.0.0
+    - poetry-core 1.0.0
   run:
     - markdown-it-py >=2.2.0,<3.0.0
     - pygments >=2.13.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,11 @@ requirements:
     - poetry-core >=1.0.10
   run:
     - markdown-it-py >=2.2.0,<3.0.0
-    - commonmark >=0.9.0,<0.10.0
-    - dataclasses >=0.7,<0.9
     - pygments >=2.13.0,<3.0.0
     - python
-    - typing_extensions >=4.0.0,<5.0.0
-
+    - typing_extensions >=4.0.0,<5.0.0  # [py<39]
+  run_constrained:
+    - ipywidgets >=7.5.1,<9
 test:
   imports:
     - rich

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - wheel
     - python
-    - poetry-core >=1.0.10
+    - poetry-core >=1.0.0
   run:
     - markdown-it-py >=2.2.0,<3.0.0
     - pygments >=2.13.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - wheel
     - python
-    - poetry-core >=1.0.0
+    - poetry-core >=1.0.0 
   run:
     - markdown-it-py >=2.2.0,<3.0.0
     - pygments >=2.13.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<37]
 
 requirements:


### PR DESCRIPTION
## Rich 13.3.5 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1829)
[Upstream](https://github.com/Textualize/rich/tree/v13.3.5)
[Dependencies ](https://github.com/Textualize/rich/blob/v13.3.5/pyproject.toml)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added `markdown-it-py` as a dependency
- Removed `commonmark` as a dependency