### PR TITLE
rich 15.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rich" %}
-{% set version = "14.2.0" %}
+{% set version = "15.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://github.com/Textualize/{{ name }}/archive/refs/tags/v{{ version  }}.tar.gz
-  sha256: 589ddd6a66adbffb9d0e406da9d529a886d2c040177da4b72fad4a8563ff5afc 
+  sha256: 5e79a8738b4e4e552291253c69e32c695de38f24400b137b119d54385234526a
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
+  skip: True  # [py<39]
 
 requirements:
   host:


### PR DESCRIPTION
rich 15.0.0

**Destination channel:** defaults

### Links

- [PKG-14808](https://anaconda.atlassian.net/browse/PKG-14808)
- [Upstream release v15.0.0](https://github.com/Textualize/rich/releases/tag/v15.0.0)
- [PyPI](https://pypi.org/project/rich/15.0.0/)

### Explanation of changes:

- Updated `rich` from 14.2.0 to 15.0.0
- Bumped `skip: True  # [py<38]` → `# [py<39]` to match upstream `requires-python >=3.9.0`
- Runtime dependencies unchanged (`markdown-it-py >=2.2.0`, `pygments >=2.13.0,<3.0.0`; `ipywidgets >=7.5.1,<9` in `run_constrained`); upstream pyproject.toml is identical here between 14.2.0 and 15.0.0
- Unblocks the genai-prices / pydantic-ai / fastmcp chain (genai-prices 0.0.57 has `run_constrained: rich >=14.3.2`, which made `pydantic-evals` and `fastmcp` unsolvable against rich 14.2.0 on pkgs/main; see [PKG-14806](https://anaconda.atlassian.net/browse/PKG-14806))

[PKG-14808]: https://anaconda.atlassian.net/browse/PKG-14808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14806]: https://anaconda.atlassian.net/browse/PKG-14806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ